### PR TITLE
Fix ended issues management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 app_tag_name = norbega/gcp-status-exporter
-version = v1.1.1
+version = v1.1.2
 
 build:
 	docker build \
@@ -15,7 +15,7 @@ tests:
 	python -m unittest -vvv test.test_main
 
 run-local:
-	docker run -d --name gcp-exporter -p '9118:9118' $(app_tag_name):$(version)
+	docker run -d --name gcp-exporter -p '9118:9118' -e MANAGE_ALL_EVENTS=True $(app_tag_name):$(version)
 
 bash-local:
 	docker exec -ti gcp-exporter sh

--- a/src/main.py
+++ b/src/main.py
@@ -86,7 +86,7 @@ class GCPStatusCollector(object):
 
         for incident in data:
             if not self.manage_all_events:
-                if incident['most_recent_update']['status'] != 'AVAILABLE':
+                if incident['most_recent_update']['status'] != 'AVAILABLE' and not 'end' in incident:
                     self.incident_handler(incident, metric)
             else:
                 self.incident_handler(incident, metric)
@@ -100,7 +100,7 @@ class GCPStatusCollector(object):
         return resp.json()
 
     def severity_handler(self, incident):
-        if incident['most_recent_update']['status'] == 'AVAILABLE':
+        if incident['most_recent_update']['status'] == 'AVAILABLE' or 'end' in incident:
             return 0
         elif incident['severity'] == 'high':
             return 2

--- a/test/fixtures/missing_available_status.json
+++ b/test/fixtures/missing_available_status.json
@@ -4,6 +4,7 @@
         "number": "13858523345881857527",
         "begin": "2021-07-27T17:35:27+00:00",
         "created": "2021-07-27T18:00:25+00:00",
+        "end": "2021-07-27T23:15:35+00:00",
         "modified": "2021-07-27T23:15:35+00:00",
         "external_desc": "us-central1: GCS is returning stale version of object for bucket",
         "updates": [
@@ -68,76 +69,5 @@
             }
         ],
         "uri": "incidents/MfiGCW4E26MPGRnCJ8by"
-    },
-    {
-        "id": "fEXXEicMtx5SaVZz2Gt7",
-        "number": "8304108178110052490",
-        "begin": "2021-07-27T16:10:35+00:00",
-        "created": "2021-07-27T16:10:36+00:00",
-        "end": "2021-07-27T22:46:11+00:00",
-        "modified": "2021-07-27T22:46:11+00:00",
-        "external_desc": "Global: Cloud Scheduler Pub/Sub jobs fail with permission denied",
-        "updates": [
-            {
-                "created": "2021-07-27T22:46:11+00:00",
-                "modified": "2021-07-27T22:46:11+00:00",
-                "when": "2021-07-27T22:46:11+00:00",
-                "text": "The issue with Cloud Scheduler has been resolved for all affected projects as of Tuesday, 2021-07-27 15:43 US/Pacific.\nWe thank you for your patience while we worked on resolving the issue.",
-                "status": "AVAILABLE"
-            },
-            {
-                "created": "2021-07-27T22:23:54+00:00",
-                "modified": "2021-07-27T22:23:55+00:00",
-                "when": "2021-07-27T22:23:54+00:00",
-                "text": "Summary: Global: Cloud Scheduler Pub/Sub jobs fail with permission denied\nDescription: We believe the issue with Cloud Scheduler is partially resolved.\nWe do not have an ETA for full resolution at this point.\nWe will provide an update by Tuesday, 2021-07-27 16:01 US/Pacific with current details.\nDiagnosis: Receiving Cloud Scheduler PERMISSION_DENIED\nWorkaround: Add the permission pubsub.topics.publish to Cloud Scheduler service account (service-PROJECT_NUMBER@gcp-sa-cloudscheduler.iam.gserviceaccount.com).",
-                "status": "SERVICE_DISRUPTION"
-            },
-            {
-                "created": "2021-07-27T20:20:24+00:00",
-                "modified": "2021-07-27T20:20:24+00:00",
-                "when": "2021-07-27T20:20:24+00:00",
-                "text": "Summary: Global: Cloud Scheduler Pub/Sub jobs fail with permission denied\nDescription: We believe the issue with Cloud Scheduler is partially resolved and there is no further impact observed.\nAction:\n- Customers should utilize the Cloud Services Robot account for authentication.\nWe will provide an update by Tuesday, 2021-07-27 15:30 US/Pacific with current details.\nDiagnosis: Receiving Cloud Scheduler PERMISSION_DENIED\nWorkaround: Add the permission pubsub.topics.publish to Cloud Scheduler service account (service-PROJECT_NUMBER@gcp-sa-cloudscheduler.iam.gserviceaccount.com).",
-                "status": "SERVICE_DISRUPTION"
-            },
-            {
-                "created": "2021-07-27T19:28:06+00:00",
-                "modified": "2021-07-27T19:28:06+00:00",
-                "when": "2021-07-27T19:28:06+00:00",
-                "text": "Summary: Global: Cloud Scheduler Pub/Sub jobs fail with permission denied\nDescription: We believe the issue with Cloud Scheduler is partially resolved and there is no further impact observed.\nAction:\n- Customers should utilize the Cloud Services Robot account for authentication.\nWe will provide an update by Tuesday, 2021-07-27 13:30 US/Pacific with current details.\nDiagnosis: Receiving Cloud Scheduler PERMISSION_DENIED\nWorkaround: Add the permission pubsub.topics.publish to Cloud Scheduler service account (service-PROJECT_NUMBER@gcp-sa-cloudscheduler.iam.gserviceaccount.com).",
-                "status": "SERVICE_DISRUPTION"
-            },
-            {
-                "created": "2021-07-27T18:03:31+00:00",
-                "modified": "2021-07-27T18:03:31+00:00",
-                "when": "2021-07-27T18:03:31+00:00",
-                "text": "Summary: Global: Cloud Scheduler Pub/Sub jobs fail with permission denied\nDescription: Mitigation work is still underway by our engineering team.\nThe rollback activity is currently 50% complete and ongoing.\nWe will provide more information by Tuesday, 2021-07-27 13:00 US/Pacific.\nDiagnosis: Receiving Cloud Scheduler PERMISSION_DENIED\nWorkaround: Add publisher role to Cloud Scheduler service account. The service account has the form service-PROJECT_NUMBER@gcp-sa-cloudscheduler.iam.gserviceaccount.com",
-                "status": "SERVICE_DISRUPTION"
-            },
-            {
-                "created": "2021-07-27T16:10:35+00:00",
-                "modified": "2021-07-27T16:10:37+00:00",
-                "when": "2021-07-27T16:10:35+00:00",
-                "text": "Summary: Global: Cloud Scheduler Pub/Sub jobs fail with permission denied\nDescription: This is a continuation of the previous post for incident \"Global: Cloud Scheduler Pub/Sub jobs fail with permission denied\" that was closed as resolved.\nWe have received updates from our engineering team that the Mitigation work is still underway for some regions and are currently waiting for an ETA.\nWe will provide more information by Tuesday, 2021-07-27 11:00 US/Pacific.\nDiagnosis: Receiving Cloud Scheduler PERMISSION_DENIED\nWorkaround: Add publisher role to Cloud Scheduler service account. The service account has the form service-PROJECT_NUMBER@gcp-sa-cloudscheduler.iam.gserviceaccount.com",
-                "status": "SERVICE_DISRUPTION"
-            }
-        ],
-        "most_recent_update": {
-            "created": "2021-07-27T22:46:11+00:00",
-            "modified": "2021-07-27T22:46:11+00:00",
-            "when": "2021-07-27T22:46:11+00:00",
-            "text": "The issue with Cloud Scheduler has been resolved for all affected projects as of Tuesday, 2021-07-27 15:43 US/Pacific.\nWe thank you for your patience while we worked on resolving the issue.",
-            "status": "AVAILABLE"
-        },
-        "status_impact": "SERVICE_DISRUPTION",
-        "severity": "medium",
-        "service_key": "Y9fKAQ6BVTQUYomrNN9A",
-        "service_name": "Google Cloud Scheduler",
-        "affected_products": [
-            {
-                "title": "Google Cloud Scheduler",
-                "id": "Y9fKAQ6BVTQUYomrNN9A"
-            }
-        ],
-        "uri": "incidents/fEXXEicMtx5SaVZz2Gt7"
     }
 ]

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -8,8 +8,12 @@ with open('test/fixtures/small.json') as fixture:
     single_issue_fixture = json.load(fixture)
     fixture.close()
 
+with open('test/fixtures/missing_available_status.json') as fixture:
+    missing_available_status_fixture = json.load(fixture)
+    fixture.close()
 
-def mocked_request_handler(*args, **kwargs):
+
+def mocked_single_request_handler(*args, **kwargs):
     class MockResponse:
         def __init__(self, json_data, status_code):
             self.json_data = json_data
@@ -21,9 +25,21 @@ def mocked_request_handler(*args, **kwargs):
     return MockResponse(single_issue_fixture, 200)
 
 
+def mocked_missing_available_request_handler(*args, **kwargs):
+    class MockResponse:
+        def __init__(self, json_data, status_code):
+            self.json_data = json_data
+            self.status_code = status_code
+
+        def json(self):
+            return self.json_data
+
+    return MockResponse(missing_available_status_fixture, 200)
+
+
 class GCPStatusCollectorTestCase(unittest.TestCase):
 
-    @mock.patch('src.main.requests.get', side_effect=mocked_request_handler)
+    @mock.patch('src.main.requests.get', side_effect=mocked_single_request_handler)
     @mock.patch('src.main.print', side_effect='Mocked')
     def test_unique_incident_with_default_parameters(self, mock_get, mock_get2):
         exporter = GCPStatusCollector(
@@ -35,7 +51,7 @@ class GCPStatusCollectorTestCase(unittest.TestCase):
         self.assertEqual(str(
             alerts[0]), "Metric(gcp_incidents, GCP Incident last update status, gauge, , [Sample(name='gcp_incidents', labels={'id': 'MfiGCW4E26MPGRnCJ8by', 'status': 'SERVICE_DISRUPTION', 'product': 'Google Cloud Storage', 'description': 'us-central1: GCS is returning stale version of object for bucket', 'uri': 'https://status.cloud.google.com/incidents/MfiGCW4E26MPGRnCJ8by'}, value=2, timestamp=None, exemplar=None)])")
 
-    @mock.patch('src.main.requests.get', side_effect=mocked_request_handler)
+    @mock.patch('src.main.requests.get', side_effect=mocked_single_request_handler)
     @mock.patch('src.main.print', side_effect='Mocked')
     def test_unique_incident_with_custom_status_endpoint(self, mock_get, mock_get2):
         exporter = GCPStatusCollector(
@@ -45,7 +61,7 @@ class GCPStatusCollectorTestCase(unittest.TestCase):
             self.assertEqual(str(
                 item), "Metric(gcp_incidents, GCP Incident last update status, gauge, , [Sample(name='gcp_incidents', labels={'id': 'MfiGCW4E26MPGRnCJ8by', 'status': 'SERVICE_DISRUPTION', 'product': 'Google Cloud Storage', 'description': 'us-central1: GCS is returning stale version of object for bucket', 'uri': 'https://my.fake.site/incidents/MfiGCW4E26MPGRnCJ8by'}, value=2, timestamp=None, exemplar=None)])")
 
-    @mock.patch('src.main.requests.get', side_effect=mocked_request_handler)
+    @mock.patch('src.main.requests.get', side_effect=mocked_single_request_handler)
     @mock.patch('src.main.print', side_effect='Mocked')
     def test_unique_incident_with_product_filter(self, mock_get, mock_get2):
         exporter = GCPStatusCollector('https://status.cloud.google.com/incidents.json', [
@@ -55,7 +71,7 @@ class GCPStatusCollectorTestCase(unittest.TestCase):
             self.assertEqual(str(
                 item), "Metric(gcp_incidents, GCP Incident last update status, gauge, , [Sample(name='gcp_incidents', labels={'id': 'MfiGCW4E26MPGRnCJ8by', 'status': 'SERVICE_DISRUPTION', 'product': 'Google Cloud Storage', 'description': 'us-central1: GCS is returning stale version of object for bucket', 'uri': 'https://status.cloud.google.com/incidents/MfiGCW4E26MPGRnCJ8by'}, value=2, timestamp=None, exemplar=None)])")
 
-    @mock.patch('src.main.requests.get', side_effect=mocked_request_handler)
+    @mock.patch('src.main.requests.get', side_effect=mocked_single_request_handler)
     @mock.patch('src.main.print', side_effect='Mocked')
     def test_unique_incident_with_zone_filter(self, mock_get, mock_get2):
         exporter = GCPStatusCollector(
@@ -65,7 +81,7 @@ class GCPStatusCollectorTestCase(unittest.TestCase):
             self.assertEqual(str(
                 item), "Metric(gcp_incidents, GCP Incident last update status, gauge, , [Sample(name='gcp_incidents', labels={'id': 'MfiGCW4E26MPGRnCJ8by', 'status': 'SERVICE_DISRUPTION', 'product': 'Google Cloud Storage', 'description': 'us-central1: GCS is returning stale version of object for bucket', 'uri': 'https://status.cloud.google.com/incidents/MfiGCW4E26MPGRnCJ8by'}, value=2, timestamp=None, exemplar=None)])")
 
-    @mock.patch('src.main.requests.get', side_effect=mocked_request_handler)
+    @mock.patch('src.main.requests.get', side_effect=mocked_single_request_handler)
     @mock.patch('src.main.print', side_effect='Mocked')
     def test_unique_incident_with_product_and_zone_filters(self, mock_get, mock_get2):
         exporter = GCPStatusCollector('https://status.cloud.google.com/incidents.json', [
@@ -76,7 +92,7 @@ class GCPStatusCollectorTestCase(unittest.TestCase):
             self.assertEqual(str(
                 item), "Metric(gcp_incidents, GCP Incident last update status, gauge, , [Sample(name='gcp_incidents', labels={'id': 'MfiGCW4E26MPGRnCJ8by', 'status': 'SERVICE_DISRUPTION', 'product': 'Google Cloud Storage', 'description': 'us-central1: GCS is returning stale version of object for bucket', 'uri': 'https://status.cloud.google.com/incidents/MfiGCW4E26MPGRnCJ8by'}, value=2, timestamp=None, exemplar=None)])")
 
-    @mock.patch('src.main.requests.get', side_effect=mocked_request_handler)
+    @mock.patch('src.main.requests.get', side_effect=mocked_single_request_handler)
     @mock.patch('src.main.print', side_effect='Mocked')
     def test_unique_incident_with_manage_all_events(self, mock_get, mock_get2):
         exporter = GCPStatusCollector(
@@ -88,7 +104,7 @@ class GCPStatusCollectorTestCase(unittest.TestCase):
                 item), "Metric(gcp_incidents, GCP Incident last update status, gauge, , [Sample(name='gcp_incidents', labels={'id': 'MfiGCW4E26MPGRnCJ8by', 'status': 'SERVICE_DISRUPTION', 'product': 'Google Cloud Storage', 'description': 'us-central1: GCS is returning stale version of object for bucket', 'uri': 'https://status.cloud.google.com/incidents/MfiGCW4E26MPGRnCJ8by'}, value=2, timestamp=None, exemplar=None), Sample(name='gcp_incidents', labels={'id': 'fEXXEicMtx5SaVZz2Gt7', 'status': 'AVAILABLE', 'product': 'Google Cloud Scheduler', 'description': 'Global: Cloud Scheduler Pub/Sub jobs fail with permission denied', 'uri': 'https://status.cloud.google.com/incidents/fEXXEicMtx5SaVZz2Gt7'}, value=0, timestamp=None, exemplar=None)])")
 
 
-    @mock.patch('src.main.requests.get', side_effect=mocked_request_handler)
+    @mock.patch('src.main.requests.get', side_effect=mocked_single_request_handler)
     @mock.patch('src.main.print', side_effect='Mocked')
     def test_unique_incident_with_extra_last_update_label(self, mock_get, mock_get2):
         exporter = GCPStatusCollector(
@@ -98,6 +114,18 @@ class GCPStatusCollectorTestCase(unittest.TestCase):
         for item in iterator:
             self.assertRegex(str(
                 item), r'^.+,\ \'last_update\'\:.+$')
+
+
+    @mock.patch('src.main.requests.get', side_effect=mocked_missing_available_request_handler)
+    @mock.patch('src.main.print', side_effect='Mocked')
+    def test_unique_solved_incident_without_available_state(self, mock_get, mock_get2):
+        exporter = GCPStatusCollector(
+            'https://status.cloud.google.com/incidents.json', [], [], True, False)
+        iterator = exporter.collect()
+        self.maxDiff = None
+        for item in iterator:
+            self.assertEqual(str(
+                item), "Metric(gcp_incidents, GCP Incident last update status, gauge, , [Sample(name='gcp_incidents', labels={'id': 'MfiGCW4E26MPGRnCJ8by', 'status': 'SERVICE_DISRUPTION', 'product': 'Google Cloud Storage', 'description': 'us-central1: GCS is returning stale version of object for bucket', 'uri': 'https://status.cloud.google.com/incidents/MfiGCW4E26MPGRnCJ8by'}, value=0, timestamp=None, exemplar=None)])")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug Fix and behavior change.

* **What is the current behavior?** (You can also link to an open issue here)

Some incidents remains with the incorrect status "SERVICE_DISRUPTION" but they are finished with an "end" date in GCP JSON and they are marked with values 1 or 2 instead of 0 in time series and are included in the metrics even if `manage_all_events` flag or `MANAGE_ALL_EVENTS` are not present.

* **What is the new behavior (if this is a feature change)?**

Right now the miss categorized events that remains with "SERVICE_DISRUPTION" state but has an "end" date are registered with 0 value in the Prometheus time series and will be not managed if `manage_all_events` flag or `MANAGE_ALL_EVENTS` are present.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
Based on @nsakovich changes: https://github.com/nsakovich/GoogleCloudStatusExporter/commit/c570ef0a2fce10d926c0a1eee6519bf929f8a6f5